### PR TITLE
Deprecate for coffee-script 1.6.4+

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # coffee-errors
 
+> ⚐ This module is [no longer needed](https://github.com/jashkenas/coffeescript/issues/3141) with coffee-script 1.6.4+
+
 Patches error stack to display correct line numbers. [CoffeeScript](http://coffeescript.org) has built in support for this, but it only works when the script is executed through the `coffee` command. If you are running mocha, node-dev, jasmine or any other method, the functionality isn't on.
 
 This is a pretty much straight copy of the original source, except it doesn't compile the source maps until necessary therefore speeding up the initial bootup process.

--- a/package.json
+++ b/package.json
@@ -18,10 +18,10 @@
     "url": "git://github.com/alexgorbatchev/coffee-errors.git"
   },
   "peerDependencies": {
-    "coffee-script": ">=1.6.2"
+    "coffee-script": "~1.6.2"
   },
   "devDependencies": {
-    "coffee-script": ">=1.6.2",
+    "coffee-script": "~1.6.2",
     "chai": "~1.8.1",
     "mocha": "~1.17.0"
   }


### PR DESCRIPTION
Hey Alex, thanks for putting this together.  Upgraded a bunch of code to coffee-script 1.8 and realized I didn't need this anymore.  Recording what I found so others can come to that conclusion faster.
